### PR TITLE
SEARCH-1060 | feat(search): support search events

### DIFF
--- a/src/MagentoDataLayerPublishManager.ts
+++ b/src/MagentoDataLayerPublishManager.ts
@@ -13,6 +13,9 @@ import {
   PRODUCT_PAGE_VIEW,
   REFERRER_URL,
   REMOVE_FROM_CART,
+  SEARCH_REQUEST_SENT,
+  SEARCH_RESPONSE_RECEIVED,
+  SEARCH_RESULT_CLICK,
   SIGN_IN,
   SIGN_OUT,
   UPDATE_CART,
@@ -82,6 +85,27 @@ export default class MagentoDataLayerPublishManager extends MagentoDataLayerBase
   }
 
   /**
+   * Publish Search Request Sent event
+   */
+  searchRequestSent(): void {
+    this.pushEvent(SEARCH_REQUEST_SENT);
+  }
+
+  /**
+   * Publish Search Response Received event
+   */
+  searchResponseReceived(): void {
+    this.pushEvent(SEARCH_RESPONSE_RECEIVED);
+  }
+
+  /**
+   * Publish Search Result Click event
+   */
+  searchResultClick(): void {
+    this.pushEvent(SEARCH_RESULT_CLICK);
+  }
+
+  /**
    * Publish Sign In event
    */
   signIn(): void {
@@ -99,6 +123,6 @@ export default class MagentoDataLayerPublishManager extends MagentoDataLayerBase
    * Publish Cart Update events
    */
   updateCart(): void {
-    this.pushEvent(UPDATE_CART)
+    this.pushEvent(UPDATE_CART);
   }
 }

--- a/src/MagentoDataLayerSubscribeManager.ts
+++ b/src/MagentoDataLayerSubscribeManager.ts
@@ -15,6 +15,9 @@ import {
   PRODUCT_PAGE_VIEW,
   REFERRER_URL,
   REMOVE_FROM_CART,
+  SEARCH_REQUEST_SENT,
+  SEARCH_RESPONSE_RECEIVED,
+  SEARCH_RESULT_CLICK,
   SIGN_IN,
   SIGN_OUT,
   UPDATE_CART,
@@ -84,6 +87,27 @@ export default class MagentoDataLayerSubscribeManager extends MagentoDataLayerBa
   }
 
   /**
+   * Subscribe to Search Request Sent event
+   */
+  searchRequestSent(handler: MagentoDataLayerEventHandler): void {
+    this.addEventListener(SEARCH_REQUEST_SENT, handler);
+  }
+
+  /**
+   * Subscribe to Search Response Received event
+   */
+  searchResponseReceived(handler: MagentoDataLayerEventHandler): void {
+    this.addEventListener(SEARCH_RESPONSE_RECEIVED, handler);
+  }
+
+  /**
+   * Subscribe to Search Result Click event
+   */
+  searchResultClick(handler: MagentoDataLayerEventHandler): void {
+    this.addEventListener(SEARCH_RESULT_CLICK, handler);
+  }
+
+  /**
    * Subscribe to Sign In event
    */
   signIn(handler: MagentoDataLayerEventHandler): void {
@@ -97,7 +121,7 @@ export default class MagentoDataLayerSubscribeManager extends MagentoDataLayerBa
     this.addEventListener(SIGN_OUT, handler);
   }
 
-  /** 
+  /**
    * Subscribe to Update Cart event
    */
   updateCart(handler: MagentoDataLayerEventHandler): void {

--- a/src/MagentoDataLayerUnsubscribeManager.ts
+++ b/src/MagentoDataLayerUnsubscribeManager.ts
@@ -14,6 +14,9 @@ import {
   PRODUCT_PAGE_VIEW,
   REFERRER_URL,
   REMOVE_FROM_CART,
+  SEARCH_REQUEST_SENT,
+  SEARCH_RESPONSE_RECEIVED,
+  SEARCH_RESULT_CLICK,
   SIGN_IN,
   SIGN_OUT,
   UPDATE_CART,
@@ -25,6 +28,7 @@ export default class MagentoDataLayerUnsubscribeManager extends MagentoDataLayer
     super();
     this.mdl = mdl;
   }
+
   /**
    *  Unsubscribe from Add to Cart event
    */
@@ -79,6 +83,27 @@ export default class MagentoDataLayerUnsubscribeManager extends MagentoDataLayer
    */
   removeFromCart(handler: MagentoDataLayerEventHandler): void {
     this.removeEventListener(REMOVE_FROM_CART, handler);
+  }
+
+  /**
+   * Unsubscribe from Search Request Sent event
+   */
+  searchRequestSent(handler: MagentoDataLayerEventHandler): void {
+    this.removeEventListener(SEARCH_REQUEST_SENT, handler);
+  }
+
+  /**
+   * Unsubscribe from Search Response Received event
+   */
+  searchResponseReceived(handler: MagentoDataLayerEventHandler): void {
+    this.removeEventListener(SEARCH_RESPONSE_RECEIVED, handler);
+  }
+
+  /**
+   * Unsubscribe from Search Result Click event
+   */
+  searchResultClick(handler: MagentoDataLayerEventHandler): void {
+    this.removeEventListener(SEARCH_RESULT_CLICK, handler);
   }
 
   /**

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,6 +25,9 @@ import {
   PRODUCT_PAGE_VIEW,
   REFERRER_URL,
   REMOVE_FROM_CART,
+  SEARCH_REQUEST_SENT,
+  SEARCH_RESPONSE_RECEIVED,
+  SEARCH_RESULT_CLICK,
   SIGN_IN,
   SIGN_OUT,
   UPDATE_CART,
@@ -236,6 +239,51 @@ describe("events", () => {
     expect(eventHandler).toHaveBeenCalledTimes(1);
     mdl.unsubscribe.removeFromCart(eventHandler);
     mdl.publish.removeFromCart();
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test("search request sent", async () => {
+    const eventHandler = jest.fn((eventObj, mdl) => {
+      expect(eventObj.event).toEqual(SEARCH_REQUEST_SENT);
+      expect(mdl).toBeInstanceOf(MagentoDataLayer);
+    });
+
+    mdl.subscribe.searchRequestSent(eventHandler);
+    expect(eventHandler).not.toHaveBeenCalled();
+    mdl.publish.searchRequestSent();
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+    mdl.unsubscribe.searchRequestSent(eventHandler);
+    mdl.publish.searchRequestSent();
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test("search response received", async () => {
+    const eventHandler = jest.fn((eventObj, mdl) => {
+      expect(eventObj.event).toEqual(SEARCH_RESPONSE_RECEIVED);
+      expect(mdl).toBeInstanceOf(MagentoDataLayer);
+    });
+
+    mdl.subscribe.searchResponseReceived(eventHandler);
+    expect(eventHandler).not.toHaveBeenCalled();
+    mdl.publish.searchResponseReceived();
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+    mdl.unsubscribe.searchResponseReceived(eventHandler);
+    mdl.publish.searchResponseReceived();
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+  });
+
+  test("search result click", async () => {
+    const eventHandler = jest.fn((eventObj, mdl) => {
+      expect(eventObj.event).toEqual(SEARCH_RESULT_CLICK);
+      expect(mdl).toBeInstanceOf(MagentoDataLayer);
+    });
+
+    mdl.subscribe.searchResultClick(eventHandler);
+    expect(eventHandler).not.toHaveBeenCalled();
+    mdl.publish.searchResultClick();
+    expect(eventHandler).toHaveBeenCalledTimes(1);
+    mdl.unsubscribe.searchResultClick(eventHandler);
+    mdl.publish.searchResultClick();
     expect(eventHandler).toHaveBeenCalledTimes(1);
   });
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -6,46 +6,37 @@
 import { MagentoDataLayer } from "..";
 
 export const ADD_TO_CART = "add-to-cart";
-export const REMOVE_FROM_CART = "remove-from-cart";
-export const UPDATE_CART = "update-cart";
-export const INITIATE_CHECKOUT = "initiate-checkout";
-export const SIGN_OUT = "sign-out";
-export const SIGN_IN = "sign-in";
-export const PAGE_ACTIVITY_SUMMARY = "page-activity-summary";
 export const CUSTOM_URL = "custom-url";
-export const REFERRER_URL = "referrer-url";
+export const INITIATE_CHECKOUT = "initiate-checkout";
+export const PAGE_ACTIVITY_SUMMARY = "page-activity-summary";
 export const PAGE_VIEW = "page-view";
 export const PRODUCT_PAGE_VIEW = "product-page-view";
+export const REFERRER_URL = "referrer-url";
+export const REMOVE_FROM_CART = "remove-from-cart";
+export const SEARCH_REQUEST_SENT = "search-request-sent";
+export const SEARCH_RESPONSE_RECEIVED = "search-response-received";
+export const SEARCH_RESULT_CLICK = "search-result-click";
+export const SIGN_IN = "sign-in";
+export const SIGN_OUT = "sign-out";
+export const UPDATE_CART = "update-cart";
 
 export type EventName =
   | typeof ADD_TO_CART
-  | typeof REMOVE_FROM_CART
-  | typeof UPDATE_CART
-  | typeof INITIATE_CHECKOUT
-  | typeof SIGN_OUT
-  | typeof SIGN_IN
-  | typeof PAGE_ACTIVITY_SUMMARY
   | typeof CUSTOM_URL
-  | typeof REFERRER_URL
+  | typeof INITIATE_CHECKOUT
+  | typeof PAGE_ACTIVITY_SUMMARY
   | typeof PAGE_VIEW
-  | typeof PRODUCT_PAGE_VIEW;
+  | typeof PRODUCT_PAGE_VIEW
+  | typeof REFERRER_URL
+  | typeof REMOVE_FROM_CART
+  | typeof SEARCH_REQUEST_SENT
+  | typeof SEARCH_RESPONSE_RECEIVED
+  | typeof SEARCH_RESULT_CLICK
+  | typeof SIGN_IN
+  | typeof SIGN_OUT
+  | typeof UPDATE_CART;
 
 export type MagentoDataLayerEventHandler = (
   eventName: EventName,
   mdl: MagentoDataLayer
 ) => void;
-
-/**
- * add-to-cart
- * remove-from-cart
- * update-cart
- * initiate-checkout
- * sign-out
- * sign-in
- * page-activity-summary
- * custom-url
- * refferer-url
- * page-view
- * product-page-view
- * product-add-to-cart
- */


### PR DESCRIPTION
## Description
Added support for `search-request-sent`, `search-response-received`, and `search-result-click` events.

## Related Issue
[SEARCH-1060](https://jira.corp.magento.com/browse/SEARCH-1060)

## Motivation and Context
Support Search reporting by enabling subscriptions to search events.

## How Has This Been Tested?
Added unit tests to check for subscribe and unsubscribe actions on each new search event.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
