### PR TITLE
feat: dATA-2871 add ability to subscribe to all events and context ch…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@adobe/magento-data-layer-sdk",
-  "version": "0.0.5",
+  "name": "magento-data-layer-sdk",
+  "version": "0.0.7",
   "description": "SDK for working with events on a Magento storefront",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -10,12 +10,12 @@
   ],
   "scripts": {
     "build": "webpack --config webpack.config.js",
-    "prepublish": "npm run build",
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
     "format": "prettier --check \"./**/*.{ts,tsx,js,css,json,md}\"",
     "format:fix": "prettier --write  \"./**/*.{ts,tsx,js,css,json,md}\"",
     "test": "jest --coverage",
+    "test:ci": "jest --ci",
     "test:watch": "jest --watch",
     "release:prod": "standard-version --dry-run",
     "release:stage": "standard-version --dry-run --prerelease stage"

--- a/src/MagentoDataLayerBase.ts
+++ b/src/MagentoDataLayerBase.ts
@@ -5,7 +5,11 @@
 
 import { MagentoDataLayer } from ".";
 import { ContextName } from "./types/contexts";
-import { EventName, MagentoDataLayerEventHandler } from "./types/events";
+import {
+  EventName,
+  ListenerOptions,
+  MagentoDataLayerEventHandler,
+} from "./types/events";
 
 export abstract class MagentoDataLayerBase {
   protected mdl!: MagentoDataLayer;
@@ -27,13 +31,14 @@ export abstract class MagentoDataLayerBase {
   // Add event listener to ACDL
   protected addEventListener(
     name: EventName,
-    handler: MagentoDataLayerEventHandler
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
   ): void {
     const wrappedHandler = (event: EventName) => handler(event, this.mdl);
 
     this.mdl._handlerMapper.set(handler, wrappedHandler);
-    window.adobeDataLayer.push((mdl: AdobeClientDataLayer) => {
-      mdl.addEventListener(name, wrappedHandler);
+    window.adobeDataLayer.push((dl: AdobeClientDataLayer) => {
+      dl.addEventListener(name, wrappedHandler, options);
     });
   }
   // Remove event listener from ACDL

--- a/src/MagentoDataLayerSubscribeManager.ts
+++ b/src/MagentoDataLayerSubscribeManager.ts
@@ -8,7 +8,10 @@ import { MagentoDataLayerBase } from "./MagentoDataLayerBase";
 import {
   ADD_TO_CART,
   CUSTOM_URL,
+  DATA_LAYER_CHANGE,
+  DATA_LAYER_EVENT,
   INITIATE_CHECKOUT,
+  ListenerOptions,
   MagentoDataLayerEventHandler,
   PAGE_ACTIVITY_SUMMARY,
   PAGE_VIEW,
@@ -33,57 +36,101 @@ export default class MagentoDataLayerSubscribeManager extends MagentoDataLayerBa
   /**
    * Subscribe to Add to Cart event
    */
-  addToCart(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(ADD_TO_CART, handler);
+  addToCart(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(ADD_TO_CART, handler, options);
   }
 
   /**
    * Subscribe to Custom Url event
    */
-  customUrl(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(CUSTOM_URL, handler);
+  customUrl(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(CUSTOM_URL, handler, options);
+  }
+
+  /**
+   * Subscribe to changes on the data layer
+   */
+  dataLayerChange(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(DATA_LAYER_CHANGE, handler, options);
+  }
+
+  /**
+   * Subscribe to all events on the data layer
+   */
+  dataLayerEvent(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(DATA_LAYER_EVENT, handler, options);
   }
 
   /**
    * Subscribe to Initiate Checkout event
    */
-  initiateCheckout(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(INITIATE_CHECKOUT, handler);
+  initiateCheckout(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(INITIATE_CHECKOUT, handler, options);
   }
 
   /**
    * Subscribe to Page Activity Summary event
    */
-  pageActivitySummary(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(PAGE_ACTIVITY_SUMMARY, handler);
+  pageActivitySummary(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(PAGE_ACTIVITY_SUMMARY, handler, options);
   }
 
   /**
    * Subscribe to Page View event
    */
-  pageView(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(PAGE_VIEW, handler);
+  pageView(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(PAGE_VIEW, handler, options);
   }
 
   /**
    * Subscribe to Product Page View event
    */
-  productPageView(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(PRODUCT_PAGE_VIEW, handler);
+  productPageView(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(PRODUCT_PAGE_VIEW, handler, options);
   }
 
   /**
    * Subscribe to Referrer Url event
    */
-  referrerUrl(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(REFERRER_URL, handler);
+  referrerUrl(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(REFERRER_URL, handler, options);
   }
 
   /**
    * Subscribe to Remove from Cart event
    */
-  removeFromCart(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(REMOVE_FROM_CART, handler);
+  removeFromCart(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(REMOVE_FROM_CART, handler, options);
   }
 
   /**
@@ -110,15 +157,21 @@ export default class MagentoDataLayerSubscribeManager extends MagentoDataLayerBa
   /**
    * Subscribe to Sign In event
    */
-  signIn(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(SIGN_IN, handler);
+  signIn(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(SIGN_IN, handler, options);
   }
 
   /**
    * Subscribe to Sign Out event
    */
-  signOut(handler: MagentoDataLayerEventHandler): void {
-    this.addEventListener(SIGN_OUT, handler);
+  signOut(
+    handler: MagentoDataLayerEventHandler,
+    options?: ListenerOptions
+  ): void {
+    this.addEventListener(SIGN_OUT, handler, options);
   }
 
   /**

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -82,7 +82,7 @@ export const generateSearchResultsContext = (
 
 export const generateShopperContext = (
   overrides?: Partial<Shopper>
-): Shopper => ({ shopperId: "test", ...overrides });
+): Shopper => ({ shopperId: "guest", ...overrides });
 
 export const generateShoppingCartContext = (
   overrides?: Partial<ShoppingCart>

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -7,6 +7,8 @@ import { MagentoDataLayer } from "..";
 
 export const ADD_TO_CART = "add-to-cart";
 export const CUSTOM_URL = "custom-url";
+export const DATA_LAYER_CHANGE = "adobeDataLayer:change";
+export const DATA_LAYER_EVENT = "adobeDataLayer:event";
 export const INITIATE_CHECKOUT = "initiate-checkout";
 export const PAGE_ACTIVITY_SUMMARY = "page-activity-summary";
 export const PAGE_VIEW = "page-view";
@@ -23,6 +25,8 @@ export const UPDATE_CART = "update-cart";
 export type EventName =
   | typeof ADD_TO_CART
   | typeof CUSTOM_URL
+  | typeof DATA_LAYER_CHANGE
+  | typeof DATA_LAYER_EVENT
   | typeof INITIATE_CHECKOUT
   | typeof PAGE_ACTIVITY_SUMMARY
   | typeof PAGE_VIEW
@@ -40,3 +44,8 @@ export type MagentoDataLayerEventHandler = (
   eventName: EventName,
   mdl: MagentoDataLayer
 ) => void;
+
+export interface ListenerOptions {
+  path?: string;
+  scope?: "past" | "future" | "all";
+}

--- a/src/types/schemas/shopper.ts
+++ b/src/types/schemas/shopper.ts
@@ -4,5 +4,5 @@
  */
 
 export interface Shopper {
-  shopperId: string;
+  shopperId: "logged-in" | "guest";
 }


### PR DESCRIPTION
…anges

fix #14

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This commit exposes the ACDL's adobeDataLayer:change and adobeDataLayer:event events as well as exposing the listener options supported by ACDL -- scope and path

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/magento-data-layer-sdk/issues/14

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change enables us to subscribe to any change in specific context paths so that we can keep global snowplow contexts up to date

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added jest tests to cover new capabilities

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
